### PR TITLE
docs: post-project UML set + index, honest Phase 2 architecture

### DIFF
--- a/docs/EXTERNAL_RUNTIME_GAPS.md
+++ b/docs/EXTERNAL_RUNTIME_GAPS.md
@@ -77,6 +77,7 @@ Full definitions: `docs/PROVENANCE_LEGEND.md`.
 
 ## Related documentation
 
+- `docs/uml/README.md` — UML index: current vs future deployment, manifest ingestion, provenance states  
 - `docs/PROVENANCE_LEGEND.md` — six evidence terms + three execution terms  
 - `docs/APPLIED_SIMULATION_BRIDGE_RUNBOOK.md` — export scripts, env var **names**  
 - `docs/AODT_EXPORT_CHECKLIST.md` — full AODT vs manifest-only  

--- a/docs/PROVENANCE_LEGEND.md
+++ b/docs/PROVENANCE_LEGEND.md
@@ -30,3 +30,5 @@ Field: `canonical_execution_status`. Long text: `execution_surface_label`.
 **Streamlit** = visualization + provenance. **Never** full AODT generation, Sionna ray trace, pyAerial PHY, or OTA capture.
 
 See `docs/EXTERNAL_RUNTIME_GAPS.md` and `docs/APPLIED_SIMULATION_BRIDGE_RUNBOOK.md`.
+
+**UML:** Evidence and execution terms are diagrammed in `docs/uml/state_provenance_evidence.mmd` and indexed in `docs/uml/README.md`.

--- a/docs/architecture/00_system_overview.md
+++ b/docs/architecture/00_system_overview.md
@@ -1,11 +1,13 @@
 # System Overview
 
+> **Diagrams:** Post-project UML (current vs future, provenance, workflows) lives under [`docs/uml/README.md`](../uml/README.md). This page is narrative; if a diagram conflicts with shipped Streamlit behavior, prefer the UML **current** set.
+
 ## Architecture Philosophy
 
 This repository implements a two-phase approach to spectrum analysis and radio resource management:
 
 1. **Competition Core**: Real-time spectrum occupancy detection from 1-second IQ samples (SpX-DAC competition requirement)
-2. **Phase 2 Research Extension**: Digital twin simulation with AI-RAN controller for resource allocation (research portfolio)
+2. **Phase 2 Research Extension**: Gary digital twin + **detector-conditioned rule-based closed-loop policy baseline (RIC-style abstraction)** in Streamlit; separate `models/` code exists for future bandit/RL study arms (not the shipped twin controller)
 
 This separation ensures that competition judges can evaluate the core detection task independently, while demonstrating our broader research vision for equitable 6G access in under-resourced communities.
 
@@ -66,60 +68,46 @@ Evaluator (metrics, submission bundle)
 
 ---
 
-## Phase 2: Research Extension — Digital Twin + AI-RAN Controller
+## Phase 2: Research Extension — Digital Twin + controller abstraction
 
-### Problem Statement
+### Problem statement
 
-Design an AI-native radio access network (RAN) controller that allocates radio resources (beams, power, resource blocks) under spectral and energy constraints, with explicit fairness considerations for mid-sized cities like Gary, Indiana.
+Study how **site-aware** RAN-style control (fairness, coexistence, energy proxies) can be grounded on **Gary’s three civic anchors**, with a clear path from **scenario → policy → KPIs** and from **proxy** to **simulation exports** to **external** validation.
 
-### System Components
+### What ships in Streamlit today (completed extension)
 
-1. **Digital Twin** (`src/edge_ran_gary/channels/`, `src/edge_ran_gary/data_pipeline/deepmimo_scenarios.py`)
-   - Sionna-based ray-tracing channel models
-   - DeepMIMO-style synthetic channel generation
-   - GIS data integration for realistic urban environments
-   - Propagation modeling for 6G-like scenarios
+1. **Gary scenario engine** (`gary_scenario_engine.py`, `gary_site_geometry.py`, digital twin generators)
+   - Three anchors: **Gary City Hall**, **Gary Public Library & Cultural Center**, **West Side Leadership Academy**
+   - People / device / traffic / pressure metrics from documented assumptions + UI presets
+   - **Detector-conditioned rule-based closed-loop policy baseline (RIC-style abstraction)** — discrete actions (hold, cautious, power, channel, prioritize, rebalance) and **heuristic KPI deltas** (`select_closed_loop_action`, `apply_action_to_kpis`)
 
-2. **AI-RAN Controller** (`src/edge_ran_gary/models/`)
-   - Contextual bandit policies (`bandit_policies.py`)
-   - Actor-critic RL agents (`actor_critic.py`)
-   - Baseline heuristics (`baselines.py`)
+2. **Simulation + provenance** (`simulation_integration_hooks.py`, `simulation_provenance.py`)
+   - Manifest-load for DeepMIMO / Sionna / AODT / pyAerial / OTA-shaped paths; **no** full local execution of external solvers in the app
 
-3. **Simulation Environment** (`src/edge_ran_gary/sim/`)
-   - Environment loop connecting channels and controllers
-   - Constraint enforcement (spectral masks, power limits)
-   - Fairness metrics across users/neighborhoods
-   - Energy efficiency tracking
+3. **pyAerial bridge** (`pyaerial_bridge/`) — import probe + **conceptual** PHY/MAC hints; real PHY remains **external**
 
-4. **Metrics** (`src/edge_ran_gary/utils/metrics.py`)
-   - Spectral efficiency (bps/Hz/user)
-   - Energy efficiency (bits/Joule)
-   - Fairness index (Jain's index, Gini coefficient)
-   - Constraint violation rates
+### Additional code (future / offline study arms, not the Streamlit controller)
 
-### Data Flow
+- **`models/`** — `bandit_policies.py`, `actor_critic.py`, `baselines.py` for **future** contextual-bandit or RL experiments (see `docs/uml/state_controller_maturity_ladder.mmd`)
+- **`sim/`**, **`channels/`**, **`data_pipeline/deepmimo_scenarios.py`** — research scaffolding; heavy Sionna/DeepMIMO **execution** is an **external runtime** target (`docs/EXTERNAL_RUNTIME_GAPS.md`)
+
+### Data flow (Streamlit extension — honest)
 
 ```
-Occupancy Probability (from Phase 1)
+Detector belief (synthetic demo IQ in Judge Mode) + scenario state
     ↓
-Digital Twin (Sionna RT + GIS)
+Rule-based policy (RIC-style abstraction)
     ↓
-Channel State Information (CSI)
+Discrete action + heuristic KPI update
     ↓
-AI-RAN Controller (bandit/RL)
-    ↓
-Resource Allocation (beams, power, RBs)
-    ↓
-Simulation Environment (constraints, fairness)
-    ↓
-Metrics & Evaluation
+pydeck scene + provenance / simulation backbone panels
 ```
 
 ---
 
 ## Why This Architecture is Credible
 
-This two-phase architecture demonstrates both practical engineering (competition core) and research innovation (Phase 2 extension). The competition core addresses the immediate SpX-DAC requirement with production-ready detection pipelines, while Phase 2 showcases our research vision for equitable 6G access. The separation allows judges to evaluate the detection task independently, while the Phase 2 components demonstrate our ability to extend beyond the competition scope into real-world RAN optimization problems. The use of established tools (Sionna, DeepMIMO) and modern ML techniques (SSL, RL) shows technical depth, while the focus on equity (Gary, Indiana) demonstrates social awareness—a combination valued by both competition judges and PhD admissions committees.
+This two-phase architecture separates **judged** detection (packaged `evaluate()`, offline scoring) from a **completed** Gary twin that already demonstrates **reproducible scenario → policy → KPI** semantics with explicit **provenance**. Optional modules (SSL, bandit/RL code under `models/`) support future study arms; they are **not** described as the current Streamlit controller. See `docs/uml/README.md` for diagrams.
 
 ---
 
@@ -130,7 +118,7 @@ src/edge_ran_gary/
 ├── data_pipeline/     # Dataset loading, preprocessing
 ├── detection/         # Competition core: occupancy detection
 ├── channels/          # Phase 2: channel modeling
-├── models/            # Phase 2: AI-RAN controllers
+├── models/            # Phase 2: bandit/RL scaffolding (future study arms; not Streamlit twin controller)
 ├── sim/               # Phase 2: simulation environment
 ├── utils/             # Shared utilities (metrics, plotting)
 └── viz/               # Visualization components

--- a/docs/uml/README.md
+++ b/docs/uml/README.md
@@ -1,0 +1,126 @@
+# UML and architecture diagrams
+
+Post-project documentation for **spectrumx-ai-ran-gary**: current deployed reality, honest extension scope, and **future research-adoption** targets. Diagrams separate:
+
+| Lane | Meaning |
+|------|---------|
+| **Judged competition core** | Binary occupancy on official SpectrumX IQ; `submissions/*/main.py` + offline evaluation |
+| **Completed research extension** | Gary digital twin (three anchors), scenario engine, **detector-conditioned rule-based closed-loop policy baseline (RIC-style abstraction)** |
+| **Future scaling / external runtime** | AODT, full Sionna RT, pyAerial/cuPHY execution, OTA/Data Lake capture — manifests and docs in-repo; execution mostly **external** |
+
+**Canonical evidence terms:** `docs/PROVENANCE_LEGEND.md`  
+**Execution boundaries:** `docs/EXTERNAL_RUNTIME_GAPS.md`  
+**Three Gary anchors:** Gary City Hall · Gary Public Library & Cultural Center · West Side Leadership Academy  
+
+**Controller (current, all diagrams):** *Detector-conditioned rule-based closed-loop policy baseline (RIC-style abstraction)* — state = detector belief + traffic/coexistence/fairness/coverage stress; actions = hold, cautious, power, channel, prioritize, rebalance; transition = heuristic KPI deltas. **Not** a trained RL or contextual-bandit policy in the shipped Streamlit path.
+
+**Future controller ladder (when shown):** rule-based baseline → contextual-bandit study arm → constrained offline RL / near-RT RIC surrogate.
+
+---
+
+## How to read this folder
+
+- **Mermaid** (`.mmd`): open in GitHub via Markdown embed, or use [Mermaid Live Editor](https://mermaid.live). Source files here are **plain Mermaid** (no markdown fences inside the file).
+- **PlantUML** (`.puml`): render with [PlantUML](https://plantuml.com/) locally, IDE plugin, or CI; see `render_plantuml.sh` if present.
+
+---
+
+## A. Current system
+
+| Diagram | Format | Purpose |
+|---------|--------|---------|
+| [system_context_current.mmd](system_context_current.mmd) | Mermaid | Actors, boundaries, manifest vs external runtime |
+| [container_view_current.puml](container_view_current.puml) | PlantUML | Major containers / packages |
+| [component_view_current.puml](component_view_current.puml) | PlantUML | Components and data flow |
+| [deployment_current.puml](deployment_current.puml) | PlantUML | Where code runs today (local, GitHub, Cloud, external) |
+
+---
+
+## B. Current workflows
+
+| Diagram | Format | Purpose |
+|---------|--------|---------|
+| [sequence_competition_inference_current.mmd](sequence_competition_inference_current.mmd) | Mermaid | IQ → evaluate / baselines → result |
+| [sequence_judge_review_flow.mmd](sequence_judge_review_flow.mmd) | Mermaid | Judge Mode narrative |
+| [sequence_extension_scenario_to_kpi_current.puml](sequence_extension_scenario_to_kpi_current.puml) | PlantUML | Scenario → rule-based controller → KPIs |
+| [activity_signal_lifecycle_current.mmd](activity_signal_lifecycle_current.mmd) | Mermaid | One-second IQ lifecycle (competition-style) |
+| [activity_signal_ecology_extension_current.mmd](activity_signal_ecology_extension_current.mmd) | Mermaid | Extension “signal ecology” (scenario-generated / illustrative) |
+| [sequence_simulation_manifest_ingestion.puml](sequence_simulation_manifest_ingestion.puml) | PlantUML | Manifest loaders + provenance finalize (no fake local AODT/pyAerial/OTA execution) |
+
+---
+
+## C. Current use cases
+
+| Diagram | Format | Purpose |
+|---------|--------|---------|
+| [use_cases_competition_core.puml](use_cases_competition_core.puml) | PlantUML | Judges, developers, evaluators |
+| [use_cases_research_extension_current.puml](use_cases_research_extension_current.puml) | PlantUML | Twin, provenance, controller semantics |
+
+---
+
+## D. Future research-adoption architecture
+
+**Explicitly target / not fully deployed.**
+
+| Diagram | Format | Purpose |
+|---------|--------|---------|
+| [system_context_future_research_adoption.puml](system_context_future_research_adoption.puml) | PlantUML | External sim, AODT, PHY, OTA, stakeholders |
+| [deployment_future_research_adoption.puml](deployment_future_research_adoption.puml) | PlantUML | Artifacts flowing back to repo/app |
+| [component_view_future_research_stack.puml](component_view_future_research_stack.puml) | PlantUML | Future stack + controller ladder |
+| [use_cases_future_research_adoption.puml](use_cases_future_research_adoption.puml) | PlantUML | Lab / city / supervisor workflows |
+
+---
+
+## E. Structure, state, and rigor
+
+| Diagram | Format | Purpose |
+|---------|--------|---------|
+| [class_diagram_detection_current.mmd](class_diagram_detection_current.mmd) | Mermaid | Actual submission + detection modules in-repo |
+| [class_diagram_extension_current.mmd](class_diagram_extension_current.mmd) | Mermaid | Scenario engine, hooks, pyAerial/OTA abstractions |
+| [state_provenance_evidence.mmd](state_provenance_evidence.mmd) | Mermaid | Six evidence tiers + three execution surfaces |
+| [state_controller_maturity_ladder.mmd](state_controller_maturity_ladder.mmd) | Mermaid | Current rule baseline vs planned study arms |
+| [activity_experiment_program_current_to_future.puml](activity_experiment_program_current_to_future.puml) | PlantUML | Experiment program → evidence tiers → external validation |
+
+---
+
+## F. Diagram legend (terminology)
+
+```mermaid
+flowchart LR
+  subgraph judged["Judged core"]
+    J[Binary occupancy detector\nsubmissions/*/main.py]
+  end
+  subgraph ext["Completed extension"]
+    E[Gary twin + scenario engine\nRule-based RIC-style controller]
+  end
+  subgraph fut["Future / external"]
+    F[Manifests only in Streamlit\nAODT / Sionna GPU / pyAerial / OTA lab]
+  end
+  judged --> ext
+  ext -.->|evidence tiers| fut
+```
+
+---
+
+## G. Legacy / superseded diagrams
+
+These reflected an **earlier aspirational** package layout (e.g. Bandit/RL as deployed Streamlit controllers, generic SSL pipeline as the only path). **Do not use for post-project accuracy.** Prefer the `*_current*` and `*_future_*` files above.
+
+| Legacy file | Issue |
+|-------------|--------|
+| [system_context.mmd](system_context.mmd) | Wrong repo topology; RL/notebooks over-emphasized |
+| [containers_components.puml](containers_components.puml) | Bandit/RL/sim as primary extension flow |
+| [deployment_streamlit.puml](deployment_streamlit.puml) | Narrow; no external-runtime boundary |
+| [sequence_inference.mmd](sequence_inference.mmd) | SSL/Ensemble/Calibrator path not matching default Streamlit `evaluate()` |
+| [class_diagram_detection.mmd](class_diagram_detection.mmd) | Many classes not wired as shown for dashboard inference |
+| [class_diagram_ml.mmd](class_diagram_ml.mmd) | Research aspirational stack |
+
+---
+
+## Related docs
+
+- [../architecture/00_system_overview.md](../architecture/00_system_overview.md) — narrative (update in prose if diagrams disagree; diagrams here reflect **Streamlit + hooks** truth for judges)
+- [../PROVENANCE_LEGEND.md](../PROVENANCE_LEGEND.md)
+- [../EXTERNAL_RUNTIME_GAPS.md](../EXTERNAL_RUNTIME_GAPS.md)
+- [../AODT_EXPORT_CHECKLIST.md](../AODT_EXPORT_CHECKLIST.md)
+- [../PYAERIAL_BRIDGE.md](../PYAERIAL_BRIDGE.md)

--- a/docs/uml/activity_experiment_program_current_to_future.puml
+++ b/docs/uml/activity_experiment_program_current_to_future.puml
@@ -1,0 +1,40 @@
+@startuml activity_experiment_program_current_to_future
+title Activity — experiment program (current proxy to future validation)
+
+start
+
+:Define research question\n(fairness / coexistence / energy under stress);
+
+:Choose independent variables\npreset, RF stress, occupancy prior,\nloaded simulation layer, policy variant;
+
+:Choose baselines\nhold-scan, fairness-off, detector-free;
+
+:Choose KPIs\ncoexistence, fairness, energy proxy,\ncontinuity, coverage proxy;
+
+:Assign **evidence tier**\nproxy-only → loaded demo →\nloaded simulation export →\nOTA-backed / external-runtime;
+
+if (Run current Streamlit path?) then (yes)
+  :Execute scenario engine +\nrule-based controller;
+  :Load manifests if on disk;
+  :Record provenance labels;
+else (no)
+endif
+
+if (Import simulation export?) then (yes)
+  :Drop JSON/GeoJSON/NPZ\nunder data/ or examples/;
+  :Re-run validators /\nreload app;
+else (no)
+endif
+
+:Evaluate KPI deltas\n(heuristic model today);
+
+:Plan **next validation tier**\nexternal Sionna / AODT /\npyAerial runtime / lab OTA;
+
+stop
+
+note right
+  See **docs/PROVENANCE_LEGEND.md**
+  and **EXTERNAL_RUNTIME_GAPS.md**
+end note
+
+@enduml

--- a/docs/uml/activity_signal_ecology_extension_current.mmd
+++ b/docs/uml/activity_signal_ecology_extension_current.mmd
@@ -1,0 +1,23 @@
+flowchart TD
+  subgraph anchors["Three Gary anchors"]
+    CH[Gary City Hall]
+    LIB[Gary Public Library and Cultural Center]
+    WSLA[West Side Leadership Academy]
+  end
+
+  A[User selects focus anchor + scenario preset] --> B[Scenario engine\nScenarioInputs to SiteScenarioState]
+  B --> C[People / devices / traffic demand\nfairness + coexistence pressure]
+  C --> D{Simulation manifests loaded?}
+  D -->|DeepMIMO / Sionna / AODT summaries| E[Merge validated fields\nprovenance finalize]
+  D -->|none| F[proxy-only analytic layer]
+  E --> G[Detector belief from synthetic demo IQ\noptional input to policy]
+  F --> G
+  G --> H[Detector-conditioned rule-based\nclosed-loop policy baseline\nRIC-style abstraction]
+  H --> I[Action: hold / cautious / power /\nchannel / prioritize / rebalance]
+  I --> J[Heuristic KPI deltas\napply_action_to_kpis]
+  J --> K[Streamlit: pydeck scene +\necology plot + backbone cards]
+
+  L[Illustrative stochastic signal ecology layer\nscenario-generated not competition waveform truth] -.-> K
+
+  style H fill:#e8daef
+  style L fill:#fdebd0,stroke:#e67e22

--- a/docs/uml/activity_signal_lifecycle_current.mmd
+++ b/docs/uml/activity_signal_lifecycle_current.mmd
@@ -1,0 +1,13 @@
+flowchart TD
+  A[Ingest 1-second IQ sample\n.npy upload or synthetic demo] --> B[Normalize format\ncomplex64 vector + sample rate]
+  B --> C[Optional: compact features\nextract_features for tables/charts]
+  B --> D[Detector path]
+  D --> D1[Submission evaluate\nor baseline threshold detectors]
+  D1 --> E[Binary label 0/1\noccupied vs noise-only]
+  E --> F[Optional confidence / probability]
+  F --> G[Render microscope\nI/Q, Welch PSD, spectrogram]
+  C --> G
+  G --> H[User / judge audit trail\nCSV metrics separate from this path]
+
+  style D1 fill:#d5e8d4
+  style E fill:#d5e8d4

--- a/docs/uml/class_diagram_detection.mmd
+++ b/docs/uml/class_diagram_detection.mmd
@@ -1,3 +1,5 @@
+%% LEGACY / aspirational ML stack — see class_diagram_detection_current.mmd
+
 ```mermaid
 classDiagram
     class DatasetLoader {

--- a/docs/uml/class_diagram_detection_current.mmd
+++ b/docs/uml/class_diagram_detection_current.mmd
@@ -1,0 +1,48 @@
+classDiagram
+  direction TB
+
+  class submission_adapter {
+    <<module>>
+    discover_submission_folders()
+    default_best_submission_folder()
+    run_evaluate_on_iq_array()
+    resolve_repo_root()
+  }
+
+  class submission_package {
+    <<submissions/pkg/main.py>>
+    evaluate(filename) int
+    optional artifact files
+  }
+
+  class feature_baseline {
+    <<module>>
+    extract_features(iq, sr) list
+  }
+
+  class detection_baselines {
+    <<module>>
+    energy_detector()
+    spectral_flatness_detector()
+  }
+
+  class judged_headline_metrics {
+    <<module>>
+    build_judged_headlines()
+  }
+
+  class streamlit_app {
+    <<apps/streamlit_app.py>>
+    load_iq_data()
+    compute_psd()
+    compute_spectrogram()
+    Judge Mode + Standard Mode
+  }
+
+  submission_adapter --> submission_package : loads
+  streamlit_app --> submission_adapter : inference
+  streamlit_app --> feature_baseline : optional features
+  streamlit_app --> detection_baselines : baseline models
+  streamlit_app --> judged_headline_metrics : CSV headlines
+
+  note for submission_package "Judged competition core boundary.\nOrganizer scoring is offline."

--- a/docs/uml/class_diagram_extension_current.mmd
+++ b/docs/uml/class_diagram_extension_current.mmd
@@ -1,0 +1,77 @@
+classDiagram
+  direction TB
+
+  class ScenarioInputs {
+    +preset
+    +rf_environment_stress
+    +manual_traffic_stress
+    +manual_occ_prior
+    +time_context
+    +event_high_load
+    +site overrides
+  }
+
+  class SiteScenarioState {
+    +site_id
+    +people_count
+    +traffic_demand_score
+    +coexistence_pressure
+    +coverage_pressure
+    +fairness_community_priority
+    +to_display_dict()
+  }
+
+  class gary_scenario_engine {
+    <<module>>
+    compute_all_anchor_states()
+    select_closed_loop_action()
+    apply_action_to_kpis()
+    propagation_proxy_bundle()
+  }
+
+  class simulation_integration_hooks {
+    <<module>>
+    load_deepmimo_*
+    load_sionna_*
+    load_aerial_*
+    load_pyaerial_bridge_status()
+    load_ota_evidence_status()
+  }
+
+  class simulation_provenance {
+    <<module>>
+    finalize_simulation_status()
+    civic_stack_summary()
+  }
+
+  class streamlit_extension {
+    <<apps/streamlit_app.py>>
+    Gary twin + pydeck + panels
+  }
+
+  class PHYBridgeStatus
+  class PHYControlPlaneHints
+  class CUMACSchedulerAbstraction
+
+  class pyaerial_bridge {
+    <<package>>
+    describe_pyaerial_environment()
+    detector_to_phy_control_plane_hints()
+    cumac_scheduler_abstraction()
+  }
+
+  ScenarioInputs --> gary_scenario_engine : drives
+  gary_scenario_engine --> SiteScenarioState : emits per anchor
+  gary_scenario_engine --> gary_scenario_engine : policy + KPI deltas
+
+  streamlit_extension --> gary_scenario_engine
+  streamlit_extension --> simulation_integration_hooks
+  streamlit_extension --> simulation_provenance : finalize + display
+  simulation_integration_hooks ..> simulation_provenance : hook dicts
+
+  pyaerial_bridge ..> PHYBridgeStatus : creates
+  pyaerial_bridge ..> PHYControlPlaneHints : creates
+  pyaerial_bridge ..> CUMACSchedulerAbstraction : creates
+  streamlit_extension --> pyaerial_bridge : optional
+
+  note for gary_scenario_engine "Detector-conditioned rule-based closed-loop policy baseline RIC-style abstraction"

--- a/docs/uml/class_diagram_ml.mmd
+++ b/docs/uml/class_diagram_ml.mmd
@@ -1,3 +1,5 @@
+%% LEGACY / aspirational — see class_diagram_detection_current.mmd
+
 ```mermaid
 classDiagram
     %% Core Interfaces

--- a/docs/uml/component_view_current.puml
+++ b/docs/uml/component_view_current.puml
@@ -1,0 +1,63 @@
+@startuml component_view_current
+title Component view — interfaces (current)
+
+left to right direction
+
+rectangle "IQ path" {
+  [load_iq_data /\ndemo generator] as iq
+  [compute_psd /\ncompute_spectrogram] as sig
+}
+
+rectangle "Inference" {
+  [run_evaluate_on_iq_array] as ev
+  [energy /\nflatness /\nPSD baselines] as base
+}
+
+rectangle "Features (optional UI)" {
+  [feature_baseline.extract_features] as feat
+}
+
+rectangle "Scenario + control" {
+  [ScenarioInputs] as si
+  [compute_all_anchor_states] as cas
+  [select_closed_loop_action\n**rule-based baseline**] as pol
+  [apply_action_to_kpis] as kpi
+}
+
+rectangle "Simulation ingest" {
+  [load_*_summary hooks] as lh
+  [finalize_simulation_status] as fin
+}
+
+rectangle "Presentation" {
+  [Streamlit panels /\nplotly / pydeck] as ui
+}
+
+iq --> ev
+iq --> base
+iq --> sig
+iq --> feat
+ev --> ui
+base --> ui
+sig --> ui
+feat --> ui
+
+si --> cas
+cas --> pol
+pol --> kpi
+cas --> ui
+kpi --> ui
+
+lh --> fin
+fin --> ui
+pol ..> iq : detector belief\nfrom session
+
+note right of pol
+  **Detector-conditioned rule-based**
+  **closed-loop policy baseline**
+  **(RIC-style abstraction)**
+  Actions: hold, cautious, power,
+  channel, prioritize, rebalance
+end note
+
+@enduml

--- a/docs/uml/component_view_future_research_stack.puml
+++ b/docs/uml/component_view_future_research_stack.puml
@@ -1,0 +1,59 @@
+@startuml component_view_future_research_stack
+title Component view — **future** research stack (target)
+
+skinparam titleFontColor #B71C1C
+
+package "Judged detector core\n(continues)" {
+  [Submission +\noffline eval] as det
+}
+
+package "Digital twin" {
+  [Gary scenario engine] as twin
+  [Geometry +\nmobility] as geo
+}
+
+package "Simulation backbone" {
+  [DeepMIMO exports] as dm
+  [Sionna RT grids] as sn
+  [AODT scene assets] as ao
+}
+
+package "Controller ladder" #E8F5E9 {
+  [Rule-based baseline\n**current**] as rb
+  [Contextual bandit\nstudy arm] as cb
+  [Offline RL /\nRIC surrogate] as rl
+}
+
+package "PHY + MAC bridge" {
+  [pyAerial +\nPHY hints] as py
+}
+
+package "OTA evidence" {
+  [Data Lake schema +\nmanifests] as ota
+}
+
+package "Provenance + experiments" {
+  [simulation_provenance] as prv
+  [experiment log /\npaper trail] as ex
+}
+
+det --> twin
+twin --> geo
+dm --> twin
+sn --> twin
+ao --> twin
+twin --> rb
+rb ..> cb : **future**
+cb ..> rl : **future**
+py ..> twin
+ota ..> prv
+twin --> prv
+det --> prv
+ex --> prv
+
+note bottom of rb
+  **Only rule-based baseline**
+  is in the current Streamlit path.
+end note
+
+@enduml

--- a/docs/uml/container_view_current.puml
+++ b/docs/uml/container_view_current.puml
@@ -1,0 +1,59 @@
+@startuml container_view_current
+title Container view — current repo (post-project)
+
+skinparam componentStyle rectangle
+skinparam wrapWidth 180
+
+package "Judged competition core" #E8F5E9 {
+  [Submission packages\nsubmissions/*/main.py] as sub
+  [submission_adapter +\ndetection baselines] as detcore
+}
+
+package "Streamlit application" #E3F2FD {
+  [apps/streamlit_app.py] as st
+  [judged_headline_metrics\nCSV strip] as jhm
+}
+
+package "Completed Gary extension" #F3E5F5 {
+  [gary_scenario_engine\nrule-based controller] as gse
+  [gary_site_geometry +\noccupancy viz + mobility] as geom
+  [digital_twin /\nmicro-twin generators] as dt
+}
+
+package "Simulation + provenance" #FFF8E1 {
+  [simulation_integration_hooks\nmanifest loaders] as hooks
+  [simulation_provenance\nfinalize + labels] as prov
+}
+
+package "Bridge + OTA (abstractions)" #FCE4EC {
+  [pyaerial_bridge\nPHY/MAC hints] as pyb
+  [ota_data_interface\nlake manifest read] as ota
+}
+
+package "Knowledge + config" #ECEFF1 {
+  [docs / UML /\nPROVENANCE_LEGEND] as docs
+  [configs/wireless_scene +\nschemas] as cfg
+}
+
+sub --> detcore
+st --> sub
+st --> detcore
+st --> jhm
+st --> gse
+st --> geom
+st --> dt
+st --> hooks
+hooks --> prov
+st --> prov
+st --> pyb
+st --> ota
+docs ..> st : human review
+cfg ..> hooks
+
+note bottom of hooks
+  DeepMIMO, Sionna RT, AODT, pyAerial, OTA:
+  **manifest-load** in Streamlit.
+  Full solvers = **external runtime**.
+end note
+
+@enduml

--- a/docs/uml/containers_components.puml
+++ b/docs/uml/containers_components.puml
@@ -1,4 +1,5 @@
 @startuml containers_components
+' LEGACY / superseded — see container_view_current.puml and docs/uml/README.md section G
 !define RECTANGLE class
 
 package "edge_ran_gary" {

--- a/docs/uml/deployment_current.puml
+++ b/docs/uml/deployment_current.puml
@@ -1,0 +1,45 @@
+@startuml deployment_current
+title Deployment — current execution surfaces (honest)
+
+node "Developer / experimenter workstation" as dev {
+  artifact "Local Python 3.x\nPYTHONPATH=repo root" as py
+  artifact "streamlit run apps/streamlit_app.py" as stl
+  artifact "scripts/*.py exports /\nvalidate_simulation_exports" as scr
+}
+
+cloud "GitHub" as gh {
+  database "gunnchOS3k/spectrumx-ai-ran-gary\nsource + docs/uml + examples/" as repo
+}
+
+cloud "Streamlit Community Cloud\n(optional)" as sc {
+  artifact "Hosted Streamlit\nsynthetic demo IQ only\nno competition IQ" as hosted
+}
+
+node "External systems\n(not this repo runtime)" as ext {
+  artifact "SpectrumX SDS /\norganizer eval" as sds
+  artifact "GPU cluster /\nSionna / DeepMIMO full solve" as gpu
+  artifact "AODT / Omniverse /\nAerial tooling" as aodt
+  artifact "Lab OTA capture" as ota
+}
+
+dev --> gh : git push / clone
+gh --> sc : deploy hook
+sc --> repo : pull
+hosted --> repo : read-only checkout
+
+py --> repo
+stl --> repo
+scr --> repo
+
+repo ..> sds : dataset download\nlocal only
+gpu ..> repo : writes manifests\nto data/ or CI artifact
+aodt ..> repo : exports summaries
+ota ..> repo : OTA lake manifests
+
+note bottom of ext
+  Streamlit **never** runs full AODT,
+  pyAerial PHY, or OTA capture.
+  It **loads** JSON/GeoJSON when present.
+end note
+
+@enduml

--- a/docs/uml/deployment_future_research_adoption.puml
+++ b/docs/uml/deployment_future_research_adoption.puml
@@ -1,0 +1,48 @@
+@startuml deployment_future_research_adoption
+title Deployment — **future research adoption** (artifact loop)
+
+skinparam titleFontColor #B71C1C
+
+node "Workstation" as ws {
+  artifact "Local dev +\nnotebooks" as dev
+}
+
+node "GPU / HPC cloud" as gpu {
+  artifact "Sionna RT /\nDeepMIMO batch" as sim
+}
+
+node "AODT / Omniverse host" as omni {
+  artifact "Scene generation +\nUSD / RF meta" as aodt
+}
+
+node "PHY lab / NVIDIA stack" as phy {
+  artifact "pyAerial +\ncuPHY-capable runtime" as pya
+}
+
+node "OTA field / lab" as field {
+  artifact "Capture + label +\nlake manifest" as ota
+}
+
+cloud "GitHub" as gh {
+  database "Repo + CI outputs" as repo
+}
+
+cloud "Streamlit / dashboard" as dash {
+  artifact "Compare runs +\nprovenance" as st
+}
+
+ws --> gh
+gpu --> gh : export bundles
+omni --> gh : summaries
+phy --> gh : bridge configs
+field --> gh : OTA manifests
+gh --> dash
+dash --> gh
+
+note bottom
+  **Future:** manifests round-trip into
+  the same **provenance vocabulary**
+  as today; execution stays **explicit**.
+end note
+
+@enduml

--- a/docs/uml/deployment_streamlit.puml
+++ b/docs/uml/deployment_streamlit.puml
@@ -1,4 +1,5 @@
 @startuml deployment_streamlit
+' LEGACY / narrow view — see deployment_current.puml and docs/uml/README.md section G
 !define DEVICE node
 
 title Streamlit Dashboard Deployment Architecture

--- a/docs/uml/render_plantuml.sh
+++ b/docs/uml/render_plantuml.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Render all PlantUML sources in this directory to SVG (optional local workflow).
+# Requires: plantuml in PATH (https://plantuml.com/starting) or:
+#   docker run --rm -v "$PWD:/work" -w /work plantuml/plantuml:latest *.puml
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+if command -v plantuml >/dev/null 2>&1; then
+  plantuml -tsvg ./*.puml
+  echo "Wrote SVG next to .puml files in $DIR"
+else
+  echo "plantuml not found. Install from https://plantuml.com/starting or use Docker image plantuml/plantuml."
+  exit 1
+fi

--- a/docs/uml/sequence_competition_inference_current.mmd
+++ b/docs/uml/sequence_competition_inference_current.mmd
@@ -1,0 +1,33 @@
+sequenceDiagram
+  autonumber
+  actor User as User / Judge
+  participant ST as Streamlit app\napps/streamlit_app.py
+  participant LO as IQ loader\nload_iq_data / synthetic demo
+  participant AD as submission_adapter\nrun_evaluate_on_iq_array
+  participant PKG as submissions/*/main.py\nevaluate
+  participant FB as feature_baseline\noptional extract_features
+  participant VZ as Plotly / UI metrics
+
+  User->>ST: Upload .npy OR demo / Judge Mode synthetic IQ
+  ST->>LO: Normalize to complex64 window
+  LO-->>ST: iq array + sample_rate
+
+  alt Final submission package
+    ST->>AD: Load module + run on iq array
+    AD->>PKG: evaluate-like path on in-memory IQ
+    PKG-->>AD: pred 0/1 + optional confidence
+    AD-->>ST: prediction + info dict
+  else Baseline detectors in Standard Mode
+    ST->>ST: energy_detector / spectral_flatness / PSD+LogReg
+    ST-->>ST: prediction + confidence
+  end
+
+  opt Interpretability panel
+    ST->>FB: extract_features(iq, sr)
+    FB-->>ST: feature rows
+  end
+
+  ST->>VZ: Time / PSD / spectrogram / microscope
+  VZ-->>User: Rendered views
+
+  Note over PKG,LE: Official leaderboard scoring uses organizer pipeline\nnot this Streamlit session

--- a/docs/uml/sequence_extension_scenario_to_kpi_current.puml
+++ b/docs/uml/sequence_extension_scenario_to_kpi_current.puml
@@ -1,0 +1,37 @@
+@startuml sequence_extension_scenario_to_kpi_current
+title Sequence — scenario to KPI (current extension, rule-based controller)
+
+actor User
+participant "Streamlit\nGary extension" as ST
+participant "gary_scenario_engine" as GSE
+participant "Detector session\n(synthetic IQ)" as DET
+participant "Simulation hooks\n(optional)" as SIM
+participant "simulation_provenance" as PRV
+
+User -> ST : Select anchor\nCity Hall / Library / WSLA
+User -> ST : Select preset +\nRF stress + calendar
+ST -> GSE : build ScenarioInputs
+ST -> GSE : compute_all_anchor_states()
+GSE --> ST : SiteScenarioState per anchor
+
+ST -> SIM : load summaries\nDeepMIMO / Sionna / AODT /\npyAerial / OTA
+SIM --> ST : hook dicts\n(manifest or absent)
+ST -> PRV : finalize_simulation_status()
+PRV --> ST : canonical evidence +\nexecution labels
+
+ST -> DET : read judge_live_pred /\nconfidence if present
+ST -> GSE : select_closed_loop_action\n(state, pred, conf, env)
+GSE --> ST : action key +\nreason string
+ST -> GSE : apply_action_to_kpis(...)
+GSE --> ST : updated KPI proxies
+
+ST --> User : Refresh pydeck +\npanels + ecology layer
+
+note over GSE
+  **Detector-conditioned rule-based**
+  **closed-loop policy baseline**
+  **(RIC-style abstraction)**
+  Heuristic KPI deltas — **not** trained RL.
+end note
+
+@enduml

--- a/docs/uml/sequence_inference.mmd
+++ b/docs/uml/sequence_inference.mmd
@@ -1,3 +1,5 @@
+%% LEGACY / superseded — see docs/uml/README.md and sequence_competition_inference_current.mmd
+
 ```mermaid
 sequenceDiagram
     actor User

--- a/docs/uml/sequence_judge_review_flow.mmd
+++ b/docs/uml/sequence_judge_review_flow.mmd
@@ -1,0 +1,31 @@
+sequenceDiagram
+  autonumber
+  actor Judge as SpectrumX judge
+  participant ST as Streamlit Judge Mode
+  participant Hero as Hero metrics strip\nsubmission_metrics.csv
+  participant Scope as Scope strip\njudged / extension / future tier
+  participant Core as Core Submission tab
+  participant Res as Results tab
+  participant Exp as Extension tab\noptional
+
+  Judge->>ST: Open app + enable Judge Mode
+  ST->>Hero: Load headline row if CSV present
+  Hero-->>Judge: Package / rank / accuracy / runtime placeholders if empty
+
+  ST->>Scope: Render three-lane scope
+  Scope-->>Judge: Judged core vs extension vs validation path
+
+  Judge->>Core: Open Core Submission
+  Core->>Core: Judged-sample microscope IQ/PSD/spec
+  Core->>Core: Live evaluate on synthetic demo IQ
+  Core-->>Judge: Prediction + confidence + inference contract note
+
+  Judge->>Res: Open Results
+  Res-->>Judge: CV / leaderboard table from CSV
+
+  opt Deeper review
+    Judge->>Exp: Completed Research Extension
+    Exp-->>Judge: Gary twin + rule-based controller semantics\nprovenance panels
+  end
+
+  Note over Judge,ST: Competition IQ not uploaded to Cloud\nsynthetic demo only for live inference

--- a/docs/uml/sequence_simulation_manifest_ingestion.puml
+++ b/docs/uml/sequence_simulation_manifest_ingestion.puml
@@ -1,0 +1,45 @@
+@startuml sequence_simulation_manifest_ingestion
+title Sequence — simulation manifest ingestion (no local full solver)
+
+participant "Streamlit app" as ST
+participant "simulation_integration_hooks" as H
+participant "Filesystem\nexamples/ + data/" as FS
+participant "simulation_provenance\nfinalize_simulation_status" as P
+
+ST -> H : load_deepmimo_scenario_summary(repo)
+H -> FS : read JSON / NPZ paths
+FS --> H : raw or empty
+H --> ST : status dict
+
+ST -> H : load_sionna_propagation_summary(repo)
+H -> FS : JSON + GeoJSON
+FS --> H
+H --> ST : status dict
+
+ST -> H : load_aerial_overlay_summary(repo)
+H -> FS : overlay_summary.json etc.
+FS --> H
+H --> ST : status dict +\ninstaller probe fields
+
+ST -> H : load_pyaerial_bridge_status(repo)
+H -> FS : bridge_manifest.json
+FS --> H
+H --> ST : status dict\n(often external-runtime-required)
+
+ST -> H : load_ota_evidence_status(repo)
+H -> FS : ota lake manifest
+FS --> H
+H --> ST : status dict
+
+ST -> P : finalize on each dict
+P --> ST : canonical_evidence_status +\ncanonical_execution_status
+
+ST -> ST : Render backbone cards\n+ civic stack strip
+
+note over H
+  **Does not** run AODT, Sionna RT GPU,
+  pyAerial PHY, or OTA capture.
+  **Reads** manifests when present.
+end note
+
+@enduml

--- a/docs/uml/state_controller_maturity_ladder.mmd
+++ b/docs/uml/state_controller_maturity_ladder.mmd
@@ -1,0 +1,18 @@
+stateDiagram-v2
+  [*] --> RuleBasedBaseline : current Streamlit extension
+
+  state "Current (shipped)" as C {
+    RuleBasedBaseline : Detector-conditioned rule-based\nclosed-loop policy baseline\nRIC-style abstraction
+  }
+
+  state "Planned study arms" as P {
+    ContextualBandit : Contextual-bandit policy learner\nfuture experiment
+    OfflineRL : Constrained offline RL\nfuture experiment
+    RICSurrogate : Near-RT RIC surrogate target\nfuture integration
+  }
+
+  RuleBasedBaseline --> ContextualBandit : next research arm
+  ContextualBandit --> OfflineRL : later arm
+  OfflineRL --> RICSurrogate : productionization path
+
+  note right of RuleBasedBaseline : select_closed_loop_action\nheuristic KPI deltas

--- a/docs/uml/state_provenance_evidence.mmd
+++ b/docs/uml/state_provenance_evidence.mmd
@@ -1,0 +1,21 @@
+flowchart LR
+  subgraph evidence["Six evidence terms (canonical)"]
+    direction TB
+    proxy[proxy-only]
+    demo[loaded demo]
+    simex[loaded simulation export]
+    inst[installer-ready]
+    ext[external-runtime-required]
+    ota[OTA-backed]
+  end
+
+  subgraph execution["Three execution surfaces"]
+    direction TB
+    mload[manifest-load-only]
+    extex[external-runtime-required]
+    lab[lab-OTA-workflow]
+  end
+
+  evidence ~~~ execution
+
+  classDef dim fill:#f8f9fa,stroke:#6c757d

--- a/docs/uml/system_context.mmd
+++ b/docs/uml/system_context.mmd
@@ -1,3 +1,5 @@
+%% LEGACY / superseded — see docs/uml/README.md section G and system_context_current.mmd
+
 ```mermaid
 flowchart TB
     subgraph External["External Systems"]

--- a/docs/uml/system_context_current.mmd
+++ b/docs/uml/system_context_current.mmd
@@ -1,0 +1,63 @@
+flowchart TB
+  subgraph actors["Actors"]
+    Judge[SpectrumX judge]
+    Collab[Team / contributor]
+    Exp[Local experimenter]
+    SU[Streamlit user]
+    Sup[Future supervisor / lab reviewer]
+  end
+
+  subgraph external_data["External data / evaluation authority"]
+    SDS[SpectrumX SDS or local dataset access\nnot shipped in public Streamlit]
+    LE[Leaderboard / organizer evaluation\noffline from this repo UI]
+  end
+
+  subgraph repo["GitHub repo: spectrumx-ai-ran-gary"]
+    Docs[docs/ UML / runbooks / provenance]
+    Sub[submissions/*/main.py\ncompetition packages]
+    Src[src/edge_ran_gary/*]
+    Man[examples/simulation_exports/**\ndata/** drop zones]
+  end
+
+  subgraph local_rt["Local Python runtime"]
+    CLI[pytest / scripts / notebooks]
+    STlocal[Streamlit local\napps/streamlit_app.py]
+  end
+
+  subgraph cloud["Streamlit Cloud optional"]
+    STcloud[Streamlit hosted app\nmanifest-load + synthetic demo IQ]
+  end
+
+  subgraph ext_run["External runtime targets\nnot executed inside Streamlit"]
+    GPU[Sionna RT / DeepMIMO full solvers\nGPU jobs]
+    AODT[AODT / Omniverse scene generation]
+    PHY[pyAerial / cuPHY / Aerial CUDA RAN]
+    OTA[OTA capture / lab workflow]
+  end
+
+  Collab --> repo
+  Exp --> local_rt
+  Exp --> SDS
+  Judge --> STcloud
+  Judge --> STlocal
+  SU --> STcloud
+  SU --> STlocal
+  Sup --> Docs
+
+  repo --> STlocal
+  repo --> STcloud
+
+  STlocal --> Sub
+  STcloud --> Sub
+  Sub --> Src
+
+  Man --> Src
+  GPU -.->|simulation exports as JSON/GeoJSON| Man
+  AODT -.->|manifests| Man
+  PHY -.->|bridge manifests / external| Man
+  OTA -.->|OTA lake manifests| Man
+
+  LE -.->|scores official IQ offline| Sub
+
+  style ext_run fill:#f9f3e6,stroke:#c9a227
+  style repo fill:#e8f4fc,stroke:#2980b9

--- a/docs/uml/system_context_future_research_adoption.puml
+++ b/docs/uml/system_context_future_research_adoption.puml
@@ -1,0 +1,48 @@
+@startuml system_context_future_research_adoption
+title System context — **future research adoption** (target architecture)
+
+skinparam titleFontColor #B71C1C
+legend
+  Target / future research adoption — not fully deployed.
+  Repo holds orchestration, docs, and manifest-load UI; heavy execution is external.
+endlegend
+
+actor "Doctoral researcher" as phd
+actor "Simulation engineer" as sim
+actor "OTA / lab engineer" as ota
+actor "City / community partner" as city
+
+package "Repo layer (orchestration)" #E3F2FD {
+  [GitHub repo\nspectrumx-ai-ran-gary] as repo
+  [docs / UML /\nexperiment registry] as docs
+  [Streamlit app\nmanifest + twin UI] as st
+}
+
+package "External simulation stack" #FFEBEE {
+  [Sionna RT GPU jobs] as sionna
+  [DeepMIMO / MATLAB pipelines] as dm
+  [AODT / Omniverse /\nAerial digital twin] as aodt
+}
+
+package "PHY + RAN targets" #FFF3E0 {
+  [pyAerial / cuPHY /\nAerial CUDA RAN] as phy
+}
+
+package "Field evidence" #E8F5E9 {
+  [OTA capture /\nData Lake ingestion] as lake
+}
+
+phd --> repo
+phd --> docs
+sim --> sionna
+sim --> dm
+sim --> aodt
+sim --> repo : manifests /\nCI artifacts
+ota --> lake
+ota --> repo : schemas /\nmanifests
+city --> docs : civic KPI co-design
+st --> repo
+
+phy ..> st : future closed-loop\nPHY hints validated
+
+@enduml

--- a/docs/uml/use_cases_competition_core.puml
+++ b/docs/uml/use_cases_competition_core.puml
@@ -1,0 +1,38 @@
+@startuml use_cases_competition_core
+title Use cases — judged competition core
+
+left to right direction
+
+actor "SpectrumX judge" as judge
+actor "Developer /\ncontributor" as dev
+actor "Leaderboard /\norganizer evaluator" as org
+actor "Local experimenter" as loc
+
+rectangle "Competition core" {
+  usecase "Review headline metrics\nfrom submission_metrics.csv" as UC1
+  usecase "Load local IQ sample\n(.npy upload or demo)" as UC2
+  usecase "Run packaged evaluate()\non in-memory IQ in Streamlit" as UC3
+  usecase "Run evaluate(filename)\noffline in Python env" as UC4
+  usecase "Compute compact features\nfor interpretability" as UC5
+  usecase "Classify occupied vs\nnoise-only (0/1)" as UC6
+  usecase "Inspect PSD /\nspectrogram /\nmicroscope" as UC7
+  usecase "Compare submission versions\ninventory + CSV" as UC8
+  usecase "Review reproducibility\nnotes + user_reqs" as UC9
+}
+
+judge --> UC1
+judge --> UC7
+dev --> UC2
+dev --> UC3
+dev --> UC4
+dev --> UC5
+dev --> UC8
+org --> UC4
+org --> UC6
+loc --> UC2
+loc --> UC3
+loc --> UC5
+UC3 ..> UC6 : <<triggers>>
+UC4 ..> UC6 : <<triggers>>
+
+@enduml

--- a/docs/uml/use_cases_future_research_adoption.puml
+++ b/docs/uml/use_cases_future_research_adoption.puml
@@ -1,0 +1,40 @@
+@startuml use_cases_future_research_adoption
+title Use cases — future research adoption (**target**, not all implemented)
+
+left to right direction
+
+actor "Lab researcher" as lr
+actor "Simulation engineer" as sim
+actor "OTA testbed engineer" as ota
+actor "City / community partner" as city
+actor "Doctoral supervisor" as sup
+
+rectangle "Future adoption (external + repo orchestration)" {
+  usecase "Import calibrated\nsimulation exports" as UC1
+  usecase "Compare scenario baselines\nfairness / energy / coverage" as UC2
+  usecase "Evaluate controller ladder\nrule → bandit → offline RL" as UC3
+  usecase "Attach pyAerial bridge\nworkflow (external PHY)" as UC4
+  usecase "Define OTA evidence schema\n+ manifests" as UC5
+  usecase "Prepare external AODT /\nSionna heavy runs" as UC6
+  usecase "Review reproducibility +\nprovenance tiers" as UC7
+  usecase "Co-design civic KPIs\nwith stakeholders" as UC8
+}
+
+lr --> UC1
+lr --> UC2
+lr --> UC7
+sim --> UC1
+sim --> UC6
+ota --> UC5
+city --> UC8
+sup --> UC3
+sup --> UC7
+
+UC3 ..> UC2 : <<informs>>
+
+note bottom of UC3
+  **Current shipped:** rule-based baseline only.
+  Bandit / offline RL = **study arms**.
+end note
+
+@enduml

--- a/docs/uml/use_cases_research_extension_current.puml
+++ b/docs/uml/use_cases_research_extension_current.puml
@@ -1,0 +1,39 @@
+@startuml use_cases_research_extension_current
+title Use cases — completed research extension (current)
+
+left to right direction
+
+actor "Research viewer" as rv
+actor "Local experimenter" as loc
+actor "Judge in Judge Mode" as judge
+actor "Supervisor /\nreviewer (future)" as sup
+
+rectangle "Gary extension + simulation UI" {
+  usecase "Select Gary anchor\nCity Hall / Library / WSLA" as UC1
+  usecase "Configure scenario preset\n+ RF stress + calendar" as UC2
+  usecase "Inspect digital twin scene\npydeck + legends" as UC3
+  usecase "Inspect KPI changes\nafter rule-based action" as UC4
+  usecase "Inspect controller semantics\nstate / action / heuristic KPI" as UC5
+  usecase "Inspect simulation +\nprovenance status cards" as UC6
+  usecase "Read future scaling path\nAODT / pyAerial / OTA docs" as UC7
+  usecase "Toggle demo vs data/\nmanifest load mode" as UC8
+}
+
+rv --> UC1
+rv --> UC3
+rv --> UC6
+loc --> UC2
+loc --> UC8
+judge --> UC1
+judge --> UC5
+judge --> UC6
+sup --> UC5
+sup --> UC7
+
+note bottom of UC5
+  **Detector-conditioned rule-based**
+  **closed-loop policy baseline**
+  **(RIC-style abstraction)**
+end note
+
+@enduml


### PR DESCRIPTION
- docs/uml/README.md: sections for current workflows, use cases, future adoption
- Mermaid: system/sequence/activity/state/class (current + provenance + controller ladder)
- PlantUML: container/component/deployment, use cases, manifest ingestion, future stack
- Legacy UML marked; architecture overview aligns with rule-based twin controller
- Cross-links from PROVENANCE_LEGEND and EXTERNAL_RUNTIME_GAPS; render_plantuml.sh

s/o cursor