### PR TITLE
Add PhD application readiness documentation

### DIFF
--- a/PULL_REQUEST_BODY.md
+++ b/PULL_REQUEST_BODY.md
@@ -1,0 +1,26 @@
+# Add PhD application readiness documentation
+
+## Summary
+
+Adds structured documentation establishing the research readiness posture for PhD applications, with Gary, Indiana as the primary proof context for AI-RAN controller and spectrum management research.
+
+## What This PR Includes
+
+- **PhD Application Readiness**: Status of all research components (concept-complete, prototype-pending, simulation-only, ethics-gated)
+- **Gary Proof Context**: Documents why Gary is compelling without claiming approvals or access
+- **Technical Simulation Plan**: What can be evaluated through simulation, tools, data sources, and reproducibility standards
+- **Ethics-Gated Fieldwork**: Clear boundaries on what requires ethics review before proceeding
+- **Metrics and Evidence**: Defined evaluation metrics and evidence each component provides
+- **GitHub Issues**: Five issues for next-phase work
+
+## What This PR Does NOT Claim
+
+- Community pilots approved
+- School district access granted
+- Human data collected or accessible
+- Live 6G or field deployment conducted
+- Any deployed system in operation
+
+## Approach
+
+All research evaluation proceeds through simulation using published public data (FCC broadband maps, Census demographics, public spectrum allocation records). Community engagement and field deployment are explicitly gated behind ethics review and governance approval.

--- a/docs/GITHUB_ISSUES_TO_CREATE.md
+++ b/docs/GITHUB_ISSUES_TO_CREATE.md
@@ -1,0 +1,69 @@
+# GitHub Issues to Create
+
+## Issue 1: Implement reproducible benchmark suite for AI-RAN controller
+
+**Labels**: enhancement, research
+
+Define and implement a benchmark suite with fixed seeds, documented parameters, and expected output baselines. Include contention scenarios, coverage optimization, and interference management evaluations.
+
+**Acceptance criteria**:
+- Benchmark configs committed to `configs/`
+- Single command runs full suite
+- Results are deterministic with fixed seed
+- Baseline outputs documented for regression detection
+
+---
+
+## Issue 2: Integrate AI-RAN controller with service-continuity middleware
+
+**Labels**: enhancement, integration
+
+Design and implement the interface between the AI-RAN controller and the service-continuity middleware layer. Define API contracts, message formats, and handoff protocols.
+
+**Acceptance criteria**:
+- Interface specification documented
+- Adapter implementation with unit tests
+- Integration test demonstrating handoff scenario
+- Error handling for middleware unavailability
+
+---
+
+## Issue 3: Document simulation experiment protocol for PhD evaluation
+
+**Labels**: documentation, research
+
+Create a comprehensive experiment protocol document covering all simulation scenarios, parameters, metrics collection, and analysis procedures. Ensure any reviewer can reproduce results.
+
+**Acceptance criteria**:
+- Protocol document in `docs/`
+- Parameter tables for each scenario
+- Analysis scripts with usage instructions
+- Sample output for validation
+
+---
+
+## Issue 4: Expand digital twin adapter for Gary-specific scenarios
+
+**Labels**: enhancement, simulation
+
+Extend the digital twin adapter to model Gary-specific conditions: geography, population density, existing infrastructure gaps, and representative demand patterns derived from public data.
+
+**Acceptance criteria**:
+- Gary geography model from public map data
+- Population density layer from Census data
+- Infrastructure gap model from FCC broadband maps
+- At least 3 representative demand scenarios
+
+---
+
+## Issue 5: Prepare IEEE conference submission materials
+
+**Labels**: documentation, research
+
+Finalize conference paper draft, prepare supplementary materials, and ensure all referenced experiments are reproducible. Align paper claims with simulation-only evidence.
+
+**Acceptance criteria**:
+- Paper draft complete with all sections
+- Figures generated from reproducible scripts
+- No claims beyond simulation evidence
+- Supplementary materials packaged for submission

--- a/docs/PHD_APPLICATION_READINESS.md
+++ b/docs/PHD_APPLICATION_READINESS.md
@@ -1,0 +1,63 @@
+# PhD Application Readiness
+
+## Role
+
+AI-RAN controller and spectrum management research for Gary, Indiana as the primary proof context.
+
+## Status
+
+**Concept-complete**
+
+## Complete
+
+- AI-RAN controller architecture
+- SpectrumX competition entry
+- Digital twin adapter
+- IEEE conference draft
+
+## Prototype-Pending
+
+- Integration with service-continuity middleware
+- Reproducible benchmarks
+
+## Simulation-Only
+
+All evaluations use simulated/modeled spectrum conditions. No live RF deployment or field measurement has been conducted.
+
+## Ethics-Gated
+
+The following require ethics review and governance approval before proceeding:
+
+- Any community engagement
+- School or library field deployment
+- Collection or use of human data
+
+## Metrics
+
+| Metric | Description |
+|--------|-------------|
+| Coverage probability | Percentage of target area with usable signal |
+| Outage rate | Frequency and duration of service interruption |
+| Latency distribution | End-to-end delay characteristics |
+| Throughput under contention | Capacity with competing users/services |
+| Reliability | Service availability over time |
+| Spectrum efficiency | Bits/Hz utilization |
+| Cost/performance ratio | Resource cost per unit of service delivered |
+
+## Evidence
+
+- AI-RAN controller code (this repository)
+- Conference draft paper
+- SpectrumX competition submission
+- Digital twin adapter implementation
+
+## Must Not Claim
+
+- Community pilots approved
+- School district access granted
+- Live 6G deployment
+- Deployed systems in operation
+
+## Fallback
+
+All research proceeds with simulation using published spectrum data (FCC broadband maps, public allocation databases) when field access is unavailable or ethics approval is pending.

--- a/docs/ethics-gated-fieldwork.md
+++ b/docs/ethics-gated-fieldwork.md
@@ -1,0 +1,48 @@
+# Ethics-Gated Fieldwork
+
+## Scope
+
+Any work involving the following requires ethics review and governance approval **before** proceeding:
+
+- Community members (interviews, surveys, observation, participation)
+- School districts (data, access, collaboration, deployment)
+- Library systems (deployment, user studies, data collection)
+- Civic organizations (partnerships, data sharing, co-design)
+
+## Red Line
+
+**No human or community data may be collected, accessed, or used before ethics approval is obtained.**
+
+This includes:
+
+- No user telemetry or network usage data from community networks
+- No interviews, focus groups, or surveys with residents
+- No observation studies in schools, libraries, or public spaces
+- No deployment of equipment in community-accessible locations
+- No collection of personally identifiable information
+
+## Approval Requirements
+
+- Institutional Review Board (IRB) approval
+- Community governance consent where applicable
+- School district authorization for any school-related scenarios
+- Library system authorization for any library-related scenarios
+- Data use agreements for any shared datasets
+
+## Fallback
+
+All research proceeds with:
+
+- Simulation using published public data
+- Modeled scenarios based on Census and FCC records
+- Synthetic workloads derived from published studies
+- No human subjects, no community interaction, no field deployment
+
+## Timeline
+
+Ethics review and community engagement are future work contingent on:
+
+1. PhD program admission and advisor alignment
+2. IRB protocol development and submission
+3. Community relationship building through appropriate channels
+4. Formal approval obtained and documented

--- a/docs/gary-proof-context.md
+++ b/docs/gary-proof-context.md
@@ -1,0 +1,36 @@
+# Gary, Indiana — Primary Proof Context
+
+## Connectivity Challenge
+
+Gary, Indiana is an underserved urban community characterized by:
+
+- Intermittent broadband availability
+- Patchy Wi-Fi coverage in public and residential areas
+- Limited cellular infrastructure investment
+- Documented gaps in digital equity
+
+## Scenario Assumptions
+
+Schools, libraries, and civic spaces serve as scenario assumptions for modeling connectivity needs. These are used as representative deployment contexts in simulation — **no approval or access is claimed**.
+
+## What Makes Gary Compelling
+
+- **Real digital equity challenge**: Persistent connectivity gaps affecting residents, students, and civic participation
+- **Specific demographics**: Well-documented population with measurable connectivity needs
+- **Documented connectivity gaps**: FCC broadband deployment data confirms underservice; public records establish baseline conditions
+- **Policy relevance**: Aligns with national broadband equity goals and spectrum access research priorities
+
+## What Is NOT Claimed
+
+- School district approval or partnership
+- Community partnership formalized with any organization
+- Access to user data or network telemetry from local providers
+- Field deployment of any system during PhD timeline
+- Consent or participation from community members
+
+## Data Sources (Public)
+
+- FCC Broadband Data Collection maps
+- Census demographic data
+- Published municipal connectivity reports
+- Public spectrum allocation records

--- a/docs/metrics-and-evidence.md
+++ b/docs/metrics-and-evidence.md
@@ -1,0 +1,42 @@
+# Metrics and Evidence
+
+## Metrics
+
+| Metric | Definition | Measurement |
+|--------|-----------|-------------|
+| Coverage probability | Percentage of target area achieving minimum signal threshold | Simulated coverage maps with threshold analysis |
+| Outage rate | Frequency and duration of service unavailability | Time-series analysis of simulated service states |
+| Latency distribution | Statistical characterization of end-to-end delay | Percentile analysis (p50, p95, p99) across scenarios |
+| Throughput under contention | Achievable data rate with competing demand | Per-user and aggregate throughput in multi-user simulation |
+| Reliability | Proportion of time service meets quality threshold | Availability percentage over simulation duration |
+| Spectrum efficiency | Data throughput per unit of spectrum resource | Bits/second/Hz across allocation strategies |
+| Cost/performance ratio | Resource expenditure per unit of delivered service | Normalized cost metric relative to baseline performance |
+
+## Evidence
+
+### AI-RAN Controller
+
+Demonstrates policy decisions including:
+
+- Dynamic spectrum allocation under varying conditions
+- Adaptive scheduling responding to demand changes
+- Interference-aware channel management
+- Priority enforcement across service classes
+
+### Digital Twin Adapter
+
+Enables scenario evaluation including:
+
+- Gary-specific geography and density modeling
+- Multi-site coverage analysis
+- Contention scenario construction
+- Comparative policy evaluation across configurations
+
+### Conference Paper
+
+Documents methodology including:
+
+- Problem formulation and system model
+- Algorithm design and complexity analysis
+- Experimental setup and evaluation protocol
+- Results interpretation and limitations

--- a/docs/technical-simulation-plan.md
+++ b/docs/technical-simulation-plan.md
@@ -1,0 +1,59 @@
+# Technical Simulation Plan
+
+## What Can Be Evaluated Through Simulation
+
+### AI-RAN Policy Decisions
+
+- Spectrum allocation strategies under varying demand
+- Dynamic channel assignment and reassignment
+- Priority-based access control policies
+- Adaptive power and coverage management
+
+### Spectrum Allocation Under Contention
+
+- Multi-user contention scenarios
+- Fairness metrics under resource scarcity
+- Time-varying demand modeling
+- Interference-aware scheduling
+
+### Coverage Optimization
+
+- Base station placement modeling
+- Beam management and coverage shaping
+- Coverage probability mapping for target areas
+- Gap identification and remediation strategies
+
+### Interference Management
+
+- Co-channel and adjacent-channel interference modeling
+- Spatial reuse optimization
+- Dynamic interference mitigation policies
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| Python-based AI-RAN controller | Policy decision engine and evaluation framework |
+| Digital twin adapter | Scenario construction and environment modeling |
+
+## Data Sources
+
+- Published spectrum allocation data (FCC databases)
+- FCC broadband deployment maps
+- Modeled user density derived from Census data
+- Synthetic traffic patterns based on published usage studies
+
+## Reproducibility
+
+All experiments document:
+
+- **Commands**: Exact invocation with parameters
+- **Parameters**: Configuration files and environment settings
+- **Expected outputs**: Baseline results for validation
+- **Random seeds**: Fixed seeds for deterministic reproduction
+- **Dependencies**: Pinned package versions
+
+```bash
+# Example experiment invocation pattern
+python run_experiment.py --config configs/contention_scenario.yaml --seed 42 --output results/
+```


### PR DESCRIPTION
Adds PhD application readiness documentation for AI-RAN Gary proof context.

## Summary
- `docs/PHD_APPLICATION_READINESS.md` — repository role, status, boundaries
- `docs/gary-proof-context.md` — Gary as primary proof context
- `docs/technical-simulation-plan.md` — simulation capabilities and reproducibility
- `docs/ethics-gated-fieldwork.md` — red-line on human/community data
- `docs/metrics-and-evidence.md` — coverage, outage, latency, spectrum metrics

## What this PR does NOT claim
- Community pilots are approved
- School access exists
- Human data has been collected
- Live deployment has occurred
- 6G access is available

Made with [Cursor](https://cursor.com)