### PR TITLE
Fix requirements typo: split scikit-learn and jsonschema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ tensorboard
 streamlit>=1.40.0,<1.45.0
 protobuf>=5.28.0,<6
 plotly
-scikit-learnjsonschema>=4.20
+scikit-learn>=1.3.0
+jsonschema>=4.20

--- a/src/edge_ran_gary/digital_twin/generator.py
+++ b/src/edge_ran_gary/digital_twin/generator.py
@@ -92,8 +92,7 @@ class SignalGenerator:
         elif zone_model:
             self.zone_model = zone_model
         else:
-            # Default: single zone
-            from .zones import Zone
+            # Default: single zone (ZoneModel already imported at module scope)
             default_zone = Zone(
                 zone_id="default",
                 weight=1.0,
@@ -103,7 +102,6 @@ class SignalGenerator:
                 cfo_range=(-1000, 1000),
                 multipath_taps_range=(1, 5)
             )
-            from .zones import ZoneModel
             self.zone_model = ZoneModel([default_zone])
     
     def generate_noise_only(self, seed: int, zone: Optional[Zone] = None) -> np.ndarray:


### PR DESCRIPTION
## Summary
- Fixes malformed dependency token `scikit-learnjsonschema>=4.20` into `scikit-learn>=1.3.0` and `jsonschema>=4.20`.
- Fixes `UnboundLocalError` in `SignalGenerator` caused by a function-local `ZoneModel` import shadowing the module import.

## Test plan
- [x] `make test` (5 passed)
- [x] `make contract-test` (4 passed)
- [x] `pytest tests/test_digital_twin_contract.py` after ZoneModel fix

## Notes
Field-kit setup currently soft-fails on this typo; after merge, field-kit will remove that suppression and refresh `integration/repo-lock.json`.


Made with [Cursor](https://cursor.com)